### PR TITLE
requirements.txt & setup.py likely reference an incorrect package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ paho_mqtt
 cryptography
 requests
 zeroconf
-attr
+attrs

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ REQUIRES = [
     "cryptography",
     "requests",
     "zeroconf",
-    "attr",
+    "attrs",
 ]
 
 setuptools.setup(


### PR DESCRIPTION
requirements.txt et al. reference ```attr```, which is an older package on PyPI[1]. This was probably a typo, as what ```attr``` provides has a substantially different use pattern.

I suspect we want ```attrs``` here[2], which matches the use in ```libdyson/cloud/device_info.py```. Swapping the package and installing it causes ```get_device.py``` to work. 

This is how I tested it:
```
% python -m venv venv
% source venv/bin/activate
% pip3 install -r requirements.txt
% python3 get_device.py
```

[1] https://pypi.org/project/attr/
[2] https://pypi.org/project/attrs/