### PR TITLE
Tests require pytest>=6.2.0

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
-pytest
+pytest>=6.2.0
 pytest-cov
 pre-commit
 black


### PR DESCRIPTION
The FixtureRequest type is only exported in pytest>=6.2.0 (see
https://github.com/pytest-dev/pytest/releases/tag/6.2.0).