### PR TITLE
Add support for new Dyson 360 Eye WiFi SSID

### DIFF
--- a/libdyson/utils.py
+++ b/libdyson/utils.py
@@ -32,9 +32,9 @@ def get_mqtt_info_from_wifi_info(
     wifi_ssid: str, wifi_password: str
 ) -> Tuple[str, str, str]:
     """Get MQTT information from WiFi information."""
-    result = re.match(r"^[0-9A-Z]{3}-[A-Z]{2}-[0-9A-Z]{8}$", wifi_ssid)
+    result = re.match(r"^(360EYE-)?(?P<serial>[0-9A-Z]{3}-[A-Z]{2}-[0-9A-Z]{8})$", wifi_ssid)
     if result is not None:
-        serial = wifi_ssid
+        serial = result.group("serial")
         device_type = DEVICE_TYPE_360_EYE
     else:
         result = re.match(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,11 @@ def test_get_mqtt_info_from_wifi_info():
         "wcosm2mJlB57tHnsxp3i8CiSz8H13J4i4p6Jw2SjdW3c+u+AZtG3PNmZ/ldaFS+Auubl5QRC/z3Lk4D3j+DQNw==",
         DEVICE_TYPE_360_EYE,
     )
+    assert get_mqtt_info_from_wifi_info("360EYE-JH1-US-GDA0001A", "z2jks80tmz") == (
+        "JH1-US-GDA0001A",
+        "wcosm2mJlB57tHnsxp3i8CiSz8H13J4i4p6Jw2SjdW3c+u+AZtG3PNmZ/ldaFS+Auubl5QRC/z3Lk4D3j+DQNw==",
+        DEVICE_TYPE_360_EYE,
+    )
     assert get_mqtt_info_from_wifi_info("DYSON-NN3-EU-HWL4729E-475", "hjkj3gjask") == (
         "NN3-EU-HWL4729E",
         "Tp+0uDTy8scsa/PnYOeBVljZJiqzIZG+A0zOe4fiRJWXVKNOI4mpnFX7gDeEl5MEO10KFDbvVn4/4hiE2vpwiw==",


### PR DESCRIPTION
Today I reset WiFi in the Dyson 360 Eye and found out that the WiFi SSID has changed from the one that is on the sticker. If the sticker has XXX-EU-XXXXXXXX the new WiFi SSID is now 360EYE-XXX-EU-XXXXXXXX. When I try to set it up with ha-dyson it fails with the message `Failed to parse device WiFi information`.

This change should still support old naming style as well as new naming style. I tried to add it to Home Assistant and the serial is still the old SSID so I had to take it from the regex.